### PR TITLE
Provide share functionality

### DIFF
--- a/demo-extended/src/main/AndroidManifest.xml
+++ b/demo-extended/src/main/AndroidManifest.xml
@@ -17,9 +17,9 @@
     </activity>
 
     <receiver
-      android:name=".ShareBroadcastReceiver"
+      android:name="com.novoda.simplechromecustomtabs.demo.ShareBroadcastReceiver"
       android:enabled="true"
-      android:exported="false"/>
+      android:exported="false" />
 
   </application>
 

--- a/demo-extended/src/main/AndroidManifest.xml
+++ b/demo-extended/src/main/AndroidManifest.xml
@@ -16,6 +16,10 @@
       </intent-filter>
     </activity>
 
+    <receiver
+      android:name=".ShareBroadcastReceiver"
+      android:enabled="true" />
+
   </application>
 
 </manifest>

--- a/demo-extended/src/main/AndroidManifest.xml
+++ b/demo-extended/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
 
     <receiver
       android:name=".ShareBroadcastReceiver"
-      android:enabled="true" />
+      android:enabled="true"
+      android:exported="false"/>
 
   </application>
 

--- a/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoActivity.java
+++ b/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoActivity.java
@@ -26,7 +26,7 @@ public class ExtendedDemoActivity extends AppCompatActivity {
 
     private static final Uri WEB_URL = Uri.parse("http://www.novoda.com");
     private static final int REQUEST_CODE_VIEW_SOURCE = 1;
-    private static final int REQUEST_CODE_NOVODA_LONDON = 2;
+    private static final int REQUEST_CODE_SHARE_URL = 2;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -73,24 +73,24 @@ public class ExtendedDemoActivity extends AppCompatActivity {
                     .withUrlBarHiding()
                     .withCloseButtonIcon(decodeCloseBitmap())
                     .withDefaultShareMenuItem()
-                    .withActionButton(decodeMapBitmap(), getString(R.string.novoda_london), navigateToNovodaLondon(), false)
+                    .withActionButton(decodeShareBitmap(), getString(R.string.share), shareUrl(), false)
                     .withMenuItem(getString(R.string.view_demo_source_code), viewSourceCode())
                     .withExitAnimations(getApplicationContext(), android.R.anim.slide_in_left, android.R.anim.fade_out)
                     .withStartAnimations(getApplicationContext(), android.R.anim.fade_in, android.R.anim.slide_out_right);
         }
     };
 
-    private Bitmap decodeMapBitmap() {
-        return BitmapFactory.decodeResource(getResources(), android.R.drawable.ic_menu_mapmode);
+    private Bitmap decodeShareBitmap() {
+        return BitmapFactory.decodeResource(getResources(), android.R.drawable.ic_menu_share);
     }
 
     private Bitmap decodeCloseBitmap() {
         return BitmapFactory.decodeResource(getResources(), R.drawable.ic_arrow_back);
     }
 
-    private PendingIntent navigateToNovodaLondon() {
-        Intent viewIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("geo:51.5411671,-0.0947801"));
-        return PendingIntent.getActivity(ExtendedDemoActivity.this, REQUEST_CODE_NOVODA_LONDON, viewIntent, 0);
+    private PendingIntent shareUrl() {
+        Intent shareIntent = new Intent(ExtendedDemoActivity.this, ShareBroadcastReceiver.class);
+        return PendingIntent.getBroadcast(ExtendedDemoActivity.this, REQUEST_CODE_SHARE_URL, shareIntent, 0);
     }
 
     private PendingIntent viewSourceCode() {

--- a/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoActivity.java
+++ b/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoActivity.java
@@ -72,6 +72,7 @@ public class ExtendedDemoActivity extends AppCompatActivity {
                     .showingTitle()
                     .withUrlBarHiding()
                     .withCloseButtonIcon(decodeCloseBitmap())
+                    .withDefaultShareMenuItem()
                     .withActionButton(decodeMapBitmap(), getString(R.string.novoda_london), navigateToNovodaLondon(), false)
                     .withMenuItem(getString(R.string.view_demo_source_code), viewSourceCode())
                     .withExitAnimations(getApplicationContext(), android.R.anim.slide_in_left, android.R.anim.fade_out)

--- a/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ShareBroadcastReceiver.java
+++ b/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ShareBroadcastReceiver.java
@@ -1,0 +1,22 @@
+package com.novoda.simplechromecustomtabs.demo;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class ShareBroadcastReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String url = intent.getDataString();
+        if (url == null) {
+            return;
+        }
+        Intent shareIntent = new Intent(Intent.ACTION_SEND);
+        shareIntent.setType("text/plain");
+        shareIntent.putExtra(Intent.EXTRA_TEXT, url);
+        Intent chooserIntent = Intent.createChooser(shareIntent, context.getString(R.string.share));
+        chooserIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(chooserIntent);
+    }
+}

--- a/demo-extended/src/main/res/values/strings.xml
+++ b/demo-extended/src/main/res/values/strings.xml
@@ -6,5 +6,5 @@
     <string name="application_found">The website will open on a Chrome Custom Tab! (custom theme).</string>
     <string name="application_not_found">You don\'t have an appropriate version of Chrome.\nWebsite will be open on default browser.</string>
     <string name="view_demo_source_code">View demo source code</string>
-    <string name="novoda_london">Novoda London</string>
+    <string name="share">Share</string>
 </resources>

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/DefaultShareMenuItemComposer.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/DefaultShareMenuItemComposer.java
@@ -1,0 +1,11 @@
+package com.novoda.simplechromecustomtabs.navigation;
+
+import android.support.customtabs.CustomTabsIntent;
+
+class DefaultShareMenuItemComposer implements Composer {
+
+    @Override
+    public CustomTabsIntent.Builder compose(CustomTabsIntent.Builder builder) {
+        return builder.addDefaultShareMenuItem();
+    }
+}

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilder.java
@@ -44,6 +44,11 @@ public class SimpleChromeCustomTabsIntentBuilder {
         return this;
     }
 
+    public SimpleChromeCustomTabsIntentBuilder withDefaultShareMenuItem() {
+        composers.add(new DefaultShareMenuItemComposer());
+        return this;
+    }
+
     public SimpleChromeCustomTabsIntentBuilder withActionButton(Bitmap icon, String description, PendingIntent pendingIntent, boolean shouldTint) {
         composers.add(new ActionButtonComposer(icon, description, pendingIntent, shouldTint));
         return this;

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilderTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilderTest.java
@@ -96,6 +96,13 @@ public class SimpleChromeCustomTabsIntentBuilderTest {
     }
 
     @Test
+    public void givenDefaultShareMenuItemIsSet_thenDefaultShareMenuItemComposerIsAdded() {
+        simpleChromeCustomTabsIntentBuilder.withDefaultShareMenuItem();
+
+        verify(mockComposers).add(any(DefaultShareMenuItemComposer.class));
+    }
+
+    @Test
     public void givenActionButtonIsSet_thenActionButtonComposerIsAdded() {
         simpleChromeCustomTabsIntentBuilder.withActionButton(ANY_ICON, ANY_DESCRIPTION, ANY_PENDING_INTENT, false);
 


### PR DESCRIPTION
### Task Requested ###

Provide a convenient way to add a `SHARE` action in a Chrome custom tab, as it may be one of the must common actions one would want to include.

### Solution implemented ###

There are actually a couple of things that this PR does:

1. Add support for the `DefaultShareMenuItem` that is already available in underlying `ChromeCustomTabs` library. By calling `SimpleChromeCustomTabsIntentBuilder.withDefaultShareMenuItem()`, the user will get a `Share...` entry in the overflow menu.
2. Illustrate in the extended demo app how one could implement a customizable `SHARE` action button. For this, we use a `PendingIntent` that will perform a broadcast with the current URL to a `BroadcastReceiver` that we had to register in the `AndroidManifest.xml`.


**Test added** 
Yes, around `DefaultShareMenuItemComposer`

Screenshots

Before | After
--- | ---
![before](https://cloud.githubusercontent.com/assets/2426348/15017090/73e27468-1214-11e6-978a-dce2e39ef8b0.png) | ![after](https://cloud.githubusercontent.com/assets/2426348/15017056/52b9df60-1214-11e6-9761-e9e450a3c3e0.png)