### PR TITLE
Release callbacks when disconnecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.novoda:simple-chrome-custom-tabs:0.1.2'
+    compile 'com.novoda:simple-chrome-custom-tabs:0.1.3'
 }
 ```    
 
@@ -59,9 +59,7 @@ And don't forget to disconnect when the `Activity` is paused.
 ```java
 @Override
 public void onPause() {
-    if (SimpleChromeCustomTabs.getInstance().isConnected()) {
-        SimpleChromeCustomTabs.getInstance().disconnectFrom(this);
-    }
+    SimpleChromeCustomTabs.getInstance().disconnectFrom(this);
     super.onPause();
 }
 ```

--- a/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoActivity.java
+++ b/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoActivity.java
@@ -20,7 +20,7 @@ import com.novoda.simplechromecustomtabs.navigation.IntentCustomizer;
 import com.novoda.simplechromecustomtabs.navigation.NavigationFallback;
 import com.novoda.simplechromecustomtabs.navigation.SimpleChromeCustomTabsIntentBuilder;
 
-import static com.novoda.simplechromecustomtabs.provider.SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback;
+import static com.novoda.simplechromecustomtabs.provider.AvailableAppProvider.PackageFoundCallback;
 
 public class ExtendedDemoActivity extends AppCompatActivity {
 

--- a/demo-simple/src/main/java/com/novoda/simplechromecustomtabs/demo/SimpleDemoActivity.java
+++ b/demo-simple/src/main/java/com/novoda/simplechromecustomtabs/demo/SimpleDemoActivity.java
@@ -11,7 +11,7 @@ import android.widget.Toast;
 import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
 import com.novoda.simplechromecustomtabs.navigation.NavigationFallback;
 
-import static com.novoda.simplechromecustomtabs.provider.SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback;
+import static com.novoda.simplechromecustomtabs.provider.AvailableAppProvider.PackageFoundCallback;
 
 public class SimpleDemoActivity extends AppCompatActivity {
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -36,7 +36,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'simple-chrome-custom-tabs'
-    publishVersion = '0.1.3-rc1'
+    publishVersion = '0.1.3'
     description = 'Provides easy integration of Chrome Custom Tabs into your project.'
     website = 'https://github.com/novoda/simplechromecustomtabs'
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -10,14 +10,11 @@ import android.support.customtabs.CustomTabsSession;
 import com.novoda.notils.exception.DeveloperError;
 import com.novoda.simplechromecustomtabs.connection.Connection;
 import com.novoda.simplechromecustomtabs.connection.Session;
-import com.novoda.simplechromecustomtabs.connection.SimpleChromeCustomTabsConnection;
 import com.novoda.simplechromecustomtabs.navigation.IntentCustomizer;
 import com.novoda.simplechromecustomtabs.navigation.NavigationFallback;
 import com.novoda.simplechromecustomtabs.navigation.SimpleChromeCustomTabsIntentBuilder;
-import com.novoda.simplechromecustomtabs.navigation.SimpleChromeCustomTabsWebNavigator;
 import com.novoda.simplechromecustomtabs.navigation.WebNavigator;
 import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
-import com.novoda.simplechromecustomtabs.provider.SimpleChromeCustomTabsAvailableAppProvider;
 
 import java.util.List;
 
@@ -46,9 +43,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
 
     public static void initialize(Context context) {
         applicationContext = context.getApplicationContext();
-        LazyHolder.INSTANCE.connection = SimpleChromeCustomTabsConnection.newInstance();
-        LazyHolder.INSTANCE.webNavigator = SimpleChromeCustomTabsWebNavigator.newInstance();
-        LazyHolder.INSTANCE.availableAppProvider = SimpleChromeCustomTabsAvailableAppProvider.newInstance();
+        LazyHolder.INSTANCE.connection = Connection.Creator.create();
+        LazyHolder.INSTANCE.webNavigator = WebNavigator.Creator.create();
+        LazyHolder.INSTANCE.availableAppProvider = AvailableAppProvider.Creator.create();
     }
 
     public Context getContext() {
@@ -157,7 +154,7 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
      * @param packageFoundCallback
      */
     @Override
-    public void findBestPackage(@NonNull SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback packageFoundCallback) {
+    public void findBestPackage(@NonNull AvailableAppProvider.PackageFoundCallback packageFoundCallback) {
         availableAppProvider.findBestPackage(packageFoundCallback);
     }
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -91,6 +91,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
         webNavigator.navigateTo(url, activityContext);
     }
 
+    /**
+     * Releases references to any set {@link IntentCustomizer} or {@link NavigationFallback}
+     */
     @Override
     public void releaseCallbacks() {
         webNavigator.releaseCallbacks();

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -92,8 +92,8 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
      * Releases references to any set {@link IntentCustomizer} or {@link NavigationFallback}
      */
     @Override
-    public void releaseCallbacks() {
-        webNavigator.releaseCallbacks();
+    public void release() {
+        webNavigator.release();
     }
 
     /**
@@ -140,7 +140,7 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
         if (isConnected()) {
             connection.disconnectFrom(activity);
         }
-        releaseCallbacks();
+        release();
     }
 
     @Override

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -91,6 +91,11 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
         webNavigator.navigateTo(url, activityContext);
     }
 
+    @Override
+    public void releaseCallbacks() {
+        webNavigator.releaseCallbacks();
+    }
+
     /**
      * Connects given activity to {@link android.support.customtabs.CustomTabsService}
      *
@@ -135,6 +140,7 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
         if (isConnected()) {
             connection.disconnectFrom(activity);
         }
+        releaseCallbacks();
     }
 
     @Override

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
@@ -9,7 +9,6 @@ import android.util.Log;
 
 import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
 import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
-import com.novoda.simplechromecustomtabs.provider.SimpleChromeCustomTabsAvailableAppProvider;
 
 class Binder {
 
@@ -32,7 +31,7 @@ class Binder {
 
         serviceConnection = new ServiceConnection(callback);
         availableAppProvider.findBestPackage(
-                new SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback() {
+                new AvailableAppProvider.PackageFoundCallback() {
                     @Override
                     public void onPackageFound(String packageName) {
                         CustomTabsClient.bindCustomTabsService(context, packageName, serviceConnection);

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Connection.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Connection.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import com.novoda.notils.exception.DeveloperError;
+
 public interface Connection {
 
     void connectTo(@NonNull Activity activity);
@@ -17,5 +19,18 @@ public interface Connection {
     void disconnectFrom(@NonNull Activity activity);
 
     boolean isDisconnected();
+
+    class Creator {
+
+        private Creator() {
+            throw new DeveloperError("Shouldn't be instantiated");
+        }
+
+        public static Connection create() {
+            Binder binder = Binder.newInstance();
+            return new SimpleChromeCustomTabsConnection(binder);
+        }
+
+    }
 
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
-public class SimpleChromeCustomTabsConnection implements Connection, ServiceConnectionCallback {
+class SimpleChromeCustomTabsConnection implements Connection, ServiceConnectionCallback {
 
     private final Binder binder;
 
@@ -14,11 +14,6 @@ public class SimpleChromeCustomTabsConnection implements Connection, ServiceConn
 
     SimpleChromeCustomTabsConnection(Binder binder) {
         this.binder = binder;
-    }
-
-    public static Connection newInstance() {
-        Binder binder = Binder.newInstance();
-        return new SimpleChromeCustomTabsConnection(binder);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigator.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigator.java
@@ -9,8 +9,8 @@ import com.novoda.simplechromecustomtabs.connection.Connection;
 class SimpleChromeCustomTabsWebNavigator implements WebNavigator {
 
     private final Connection connection;
-    private NavigationFallback navigationFallback;
-    private IntentCustomizer intentCustomizer;
+    NavigationFallback navigationFallback;
+    IntentCustomizer intentCustomizer;
 
     SimpleChromeCustomTabsWebNavigator(Connection connection) {
         this.connection = connection;

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigator.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigator.java
@@ -4,10 +4,9 @@ import android.app.Activity;
 import android.net.Uri;
 import android.support.customtabs.CustomTabsIntent;
 
-import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
 import com.novoda.simplechromecustomtabs.connection.Connection;
 
-public class SimpleChromeCustomTabsWebNavigator implements WebNavigator {
+class SimpleChromeCustomTabsWebNavigator implements WebNavigator {
 
     private final Connection connection;
     private NavigationFallback navigationFallback;
@@ -15,11 +14,6 @@ public class SimpleChromeCustomTabsWebNavigator implements WebNavigator {
 
     SimpleChromeCustomTabsWebNavigator(Connection connection) {
         this.connection = connection;
-    }
-
-    public static WebNavigator newInstance() {
-        Connection connection = SimpleChromeCustomTabs.getInstance();
-        return new SimpleChromeCustomTabsWebNavigator(connection);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigator.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigator.java
@@ -43,6 +43,12 @@ public class SimpleChromeCustomTabsWebNavigator implements WebNavigator {
         }
     }
 
+    @Override
+    public void releaseCallbacks() {
+        intentCustomizer = null;
+        navigationFallback = null;
+    }
+
     private CustomTabsIntent buildIntent() {
         SimpleChromeCustomTabsIntentBuilder basicIntentBuilder = SimpleChromeCustomTabsIntentBuilder.newInstance(connection);
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigator.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigator.java
@@ -38,7 +38,7 @@ class SimpleChromeCustomTabsWebNavigator implements WebNavigator {
     }
 
     @Override
-    public void releaseCallbacks() {
+    public void release() {
         intentCustomizer = null;
         navigationFallback = null;
     }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/WebNavigator.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/WebNavigator.java
@@ -15,7 +15,7 @@ public interface WebNavigator {
 
     void navigateTo(Uri url, Activity activityContext);
 
-    void releaseCallbacks();
+    void release();
 
     class Creator {
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/WebNavigator.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/WebNavigator.java
@@ -3,6 +3,10 @@ package com.novoda.simplechromecustomtabs.navigation;
 import android.app.Activity;
 import android.net.Uri;
 
+import com.novoda.notils.exception.DeveloperError;
+import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
+import com.novoda.simplechromecustomtabs.connection.Connection;
+
 public interface WebNavigator {
 
     WebNavigator withFallback(NavigationFallback navigationFallback);
@@ -12,5 +16,18 @@ public interface WebNavigator {
     void navigateTo(Uri url, Activity activityContext);
 
     void releaseCallbacks();
+
+    class Creator {
+
+        private Creator() {
+            throw new DeveloperError("Shouldn't be instantiated");
+        }
+
+        public static WebNavigator create() {
+            Connection connection = SimpleChromeCustomTabs.getInstance();
+            return new SimpleChromeCustomTabsWebNavigator(connection);
+        }
+
+    }
 
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/WebNavigator.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/WebNavigator.java
@@ -11,4 +11,6 @@ public interface WebNavigator {
 
     void navigateTo(Uri url, Activity activityContext);
 
+    void releaseCallbacks();
+
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/provider/AvailableAppProvider.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/provider/AvailableAppProvider.java
@@ -2,8 +2,32 @@ package com.novoda.simplechromecustomtabs.provider;
 
 import android.support.annotation.NonNull;
 
+import com.novoda.notils.exception.DeveloperError;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
 public interface AvailableAppProvider {
 
     void findBestPackage(@NonNull SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback packageFoundCallback);
+
+    interface PackageFoundCallback {
+        void onPackageFound(String packageName);
+
+        void onPackageNotFound();
+    }
+
+    class Creator {
+
+        private Creator() {
+            throw new DeveloperError("Shouldn't be instantiated");
+        }
+
+        public static AvailableAppProvider create() {
+            BestPackageFinder bestPackageFinder = BestPackageFinder.newInstance();
+            Executor executor = Executors.newSingleThreadExecutor();
+            return new SimpleChromeCustomTabsAvailableAppProvider(bestPackageFinder, executor);
+        }
+    }
 
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/provider/SimpleChromeCustomTabsAvailableAppProvider.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/provider/SimpleChromeCustomTabsAvailableAppProvider.java
@@ -5,9 +5,8 @@ import android.support.annotation.WorkerThread;
 import android.text.TextUtils;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
-public class SimpleChromeCustomTabsAvailableAppProvider implements AvailableAppProvider {
+class SimpleChromeCustomTabsAvailableAppProvider implements AvailableAppProvider {
 
     private final BestPackageFinder bestPackageFinder;
     private final Executor executor;
@@ -15,12 +14,6 @@ public class SimpleChromeCustomTabsAvailableAppProvider implements AvailableAppP
     SimpleChromeCustomTabsAvailableAppProvider(BestPackageFinder bestPackageFinder, Executor executor) {
         this.bestPackageFinder = bestPackageFinder;
         this.executor = executor;
-    }
-
-    public static AvailableAppProvider newInstance() {
-        BestPackageFinder bestPackageFinder = BestPackageFinder.newInstance();
-        Executor executor = Executors.newSingleThreadExecutor();
-        return new SimpleChromeCustomTabsAvailableAppProvider(bestPackageFinder, executor);
     }
 
     @Override
@@ -42,12 +35,6 @@ public class SimpleChromeCustomTabsAvailableAppProvider implements AvailableAppP
                 }
             }
         };
-    }
-
-    public interface PackageFoundCallback {
-        void onPackageFound(String packageName);
-
-        void onPackageNotFound();
     }
 
 }

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/connection/BinderTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/connection/BinderTest.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 
 import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
-import com.novoda.simplechromecustomtabs.provider.SimpleChromeCustomTabsAvailableAppProvider;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,7 +14,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 
-import static com.novoda.simplechromecustomtabs.provider.SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback;
+import static com.novoda.simplechromecustomtabs.provider.AvailableAppProvider.PackageFoundCallback;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -29,7 +28,7 @@ public class BinderTest {
     @Mock
     private AvailableAppProvider mockAvailableAppProvider;
     @Captor
-    private ArgumentCaptor<SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback> packageFoundCallbackCaptor;
+    private ArgumentCaptor<AvailableAppProvider.PackageFoundCallback> packageFoundCallbackCaptor;
 
     private Binder binder;
 

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilderTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilderTest.java
@@ -5,8 +5,8 @@ import android.graphics.Bitmap;
 import android.support.customtabs.CustomTabsIntent;
 
 import com.novoda.notils.exception.DeveloperError;
+import com.novoda.simplechromecustomtabs.connection.Connection;
 import com.novoda.simplechromecustomtabs.connection.Session;
-import com.novoda.simplechromecustomtabs.connection.SimpleChromeCustomTabsConnection;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +34,7 @@ public class SimpleChromeCustomTabsIntentBuilderTest {
     private static final Context ANY_CONTEXT = Robolectric.application;
 
     @Mock
-    private SimpleChromeCustomTabsConnection mockSimpleChromeCustomTabsConnection;
+    private Connection mockConnection;
     @Mock
     private List<Composer> mockComposers;
 
@@ -44,9 +44,9 @@ public class SimpleChromeCustomTabsIntentBuilderTest {
     public void setUp() {
         initMocks(this);
 
-        simpleChromeCustomTabsIntentBuilder = new SimpleChromeCustomTabsIntentBuilder(mockSimpleChromeCustomTabsConnection, mockComposers);
+        simpleChromeCustomTabsIntentBuilder = new SimpleChromeCustomTabsIntentBuilder(mockConnection, mockComposers);
         when(mockComposers.iterator()).thenReturn(Collections.<Composer>emptyListIterator());
-        when(mockSimpleChromeCustomTabsConnection.getSession()).thenReturn(mock(Session.class));
+        when(mockConnection.getSession()).thenReturn(mock(Session.class));
     }
 
     @Test(expected = DeveloperError.class)
@@ -62,7 +62,7 @@ public class SimpleChromeCustomTabsIntentBuilderTest {
 
         simpleChromeCustomTabsIntentBuilder.createIntent();
 
-        verify(mockSimpleChromeCustomTabsConnection).getSession();
+        verify(mockConnection).getSession();
     }
 
     @Test
@@ -138,11 +138,11 @@ public class SimpleChromeCustomTabsIntentBuilderTest {
     }
 
     private void givenIsDisconnected() {
-        when(mockSimpleChromeCustomTabsConnection.isDisconnected()).thenReturn(true);
+        when(mockConnection.isDisconnected()).thenReturn(true);
     }
 
     private void givenIsConnected() {
-        when(mockSimpleChromeCustomTabsConnection.isConnected()).thenReturn(true);
+        when(mockConnection.isConnected()).thenReturn(true);
     }
 
 }

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsNavigatorTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsNavigatorTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
+import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -35,7 +36,7 @@ public class SimpleChromeCustomTabsNavigatorTest {
     @Mock
     private SimpleChromeCustomTabsIntentBuilder mockSimpleChromeCustomTabsIntentBuilder;
 
-    private WebNavigator webNavigator;
+    private SimpleChromeCustomTabsWebNavigator webNavigator;
 
     @Before
     public void setUp() {
@@ -83,6 +84,16 @@ public class SimpleChromeCustomTabsNavigatorTest {
         webNavigator.withIntentCustomizer(mockIntentCustomizer).navigateTo(ANY_URL, mockActivity);
 
         verify(mockIntentCustomizer).onCustomiseIntent(any(SimpleChromeCustomTabsIntentBuilder.class));
+    }
+
+    @Test
+    public void givenThereAreCallbacks_whenReleaseIsCalled_thenCallbacksAreReleased() {
+        webNavigator.withFallback(mockNavigationFallback).withIntentCustomizer(mockIntentCustomizer);
+
+        webNavigator.release();
+
+        assertThat(webNavigator.intentCustomizer).isNull();
+        assertThat(webNavigator.navigationFallback).isNull();
     }
 
 }

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigatorTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigatorTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(RobolectricTestRunner.class)
-public class SimpleChromeCustomTabsNavigatorTest {
+public class SimpleChromeCustomTabsWebNavigatorTest {
 
     private static final Uri ANY_URL = Uri.EMPTY;
     private static final CustomTabsIntent ANY_INTENT = new CustomTabsIntent.Builder().build();


### PR DESCRIPTION
### Task Requested

Callbacks references in `SimpleChromeCustomTabsWebNavigator` were not released when `SimpleChromeCustomTabs` instance disconnected from the activity, leading to a memory leak
### Solution implemented

Add a `release()` method to `WebNavigator` and implement it

**Test added**

Yes, added test in `SimpleChromeCustomTabsWebNavigatorTest` to check that the callbacks were released.

Screenshots

| Before | After |
| --- | --- |
| ![screenshot 2016-10-03 12 12 46](https://cloud.githubusercontent.com/assets/2426348/19034709/4ddecaf0-8965-11e6-88a9-56046fb843c1.png) | ![screenshot 2016-10-03 12 19 18](https://cloud.githubusercontent.com/assets/2426348/19034730/6f3693d6-8965-11e6-8a11-9b67c8dd2d37.png) |
