### PR TITLE
Update Robolectric to latest version (3.1.4)

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'
-    testCompile 'org.robolectric:robolectric:2.4'
+    testCompile 'org.robolectric:robolectric:3.1.4'
 }
 
 publish {

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
@@ -4,8 +4,8 @@ import com.novoda.notils.exception.DeveloperError;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -19,7 +19,7 @@ public class SimpleChromeCustomTabsTest {
 
     @Test
     public void givenSimpleChromeCustomTabsIsInitialised_whenGettingInstance_thenInstanceIsReturned() {
-        SimpleChromeCustomTabs.initialize(Robolectric.application);
+        SimpleChromeCustomTabs.initialize(RuntimeEnvironment.application);
 
         assertThat(SimpleChromeCustomTabs.getInstance()).isInstanceOf(SimpleChromeCustomTabs.class);
     }

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnectionTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnectionTest.java
@@ -5,12 +5,16 @@ import android.net.Uri;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+@RunWith(RobolectricTestRunner.class)
 public class SimpleChromeCustomTabsConnectionTest {
 
     private static Uri ANY_URI = mock(Uri.class);
@@ -30,7 +34,7 @@ public class SimpleChromeCustomTabsConnectionTest {
     public void setUp() {
         initMocks(this);
 
-        when(mockActivity.getApplicationContext()).thenReturn(Robolectric.application);
+        when(mockActivity.getApplicationContext()).thenReturn(RuntimeEnvironment.application);
         when(mockConnectedClient.newSession()).thenReturn(mock(Session.class));
 
         simpleChromeCustomTabsConnection = new SimpleChromeCustomTabsConnection(mockBinder);

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilderTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsIntentBuilderTest.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -31,7 +32,7 @@ public class SimpleChromeCustomTabsIntentBuilderTest {
     private static final String ANY_LABEL = "anyLabel";
     private static final String ANY_DESCRIPTION = "any_description";
     private static final Bitmap ANY_ICON = null;
-    private static final Context ANY_CONTEXT = Robolectric.application;
+    private static final Context ANY_CONTEXT = RuntimeEnvironment.application;
 
     @Mock
     private SimpleChromeCustomTabsConnection mockSimpleChromeCustomTabsConnection;

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsNavigatorTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsNavigatorTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -41,7 +42,7 @@ public class SimpleChromeCustomTabsNavigatorTest {
     public void setUp() {
         initMocks(this);
 
-        SimpleChromeCustomTabs.initialize(Robolectric.application);
+        SimpleChromeCustomTabs.initialize(RuntimeEnvironment.application);
         when(mockIntentCustomizer.onCustomiseIntent(any(SimpleChromeCustomTabsIntentBuilder.class))).thenReturn(mockSimpleChromeCustomTabsIntentBuilder);
         when(mockSimpleChromeCustomTabsIntentBuilder.createIntent()).thenReturn(ANY_INTENT);
         when(mockConnection.getSession()).thenReturn(Session.NULL_SESSION);


### PR DESCRIPTION
### Task Requested ###

The version of Robolectric used in tests is quite old (2.4).

### Solution implemented ###

Updated Robolectric dependency to 3.1.4. Amended the existing tests to deal with the changes in the Robolectric API.

#### Screenshots

No UI changes, therefore no screenshots.
