### PR TITLE
Fix broken test java 8 issue

### DIFF
--- a/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
@@ -15,6 +15,10 @@ public class SimpleChromeCustomTabsTest {
 
     @Test
     public void givenSimpleChromeCustomTabsIsNotInitialised_whenGettingInstance_thenDeveloperErrorIsThrown() {
+        /** Please forgive me for what you are seeing. Given some incompatibility issues between Robolectric 3.1.4 and some versions of
+         *  Java 8, the @Test(expected = DeveloperError.class) wasn't working.
+         *  Will fix when we figure out how.
+         **/
         try {
             SimpleChromeCustomTabs.getInstance();
             fail("A Developer error exception was expected, but there was nothing");

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
@@ -8,13 +8,19 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.fail;
 
 @RunWith(RobolectricTestRunner.class)
 public class SimpleChromeCustomTabsTest {
 
-    @Test(expected = DeveloperError.class)
+    @Test
     public void givenSimpleChromeCustomTabsIsNotInitialised_whenGettingInstance_thenDeveloperErrorIsThrown() {
-        SimpleChromeCustomTabs.getInstance();
+        try {
+            SimpleChromeCustomTabs.getInstance();
+            fail("A Developer error exception was expected, but there was nothing");
+        } catch (DeveloperError e) {
+            // passes
+        }
     }
 
     @Test


### PR DESCRIPTION
### Task Requested ###

Given some incompatibility issues between Robolectric 3.1.4 and some java 8 versions the clause `@Test(expected = DeveloperError.class)` wasn't working. 

This is a hacky workaround to that.

### Solution implemented ###

See changelog.
