### PR TITLE
Remove static initialiser

### DIFF
--- a/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoActivity.java
+++ b/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoActivity.java
@@ -108,7 +108,7 @@ public class ExtendedDemoActivity extends AppCompatActivity {
     }
 
     private void checkForPackageAvailable() {
-        SimpleChromeCustomTabs.getInstance().findBestPackage(packageFoundCallback);
+        SimpleChromeCustomTabs.getInstance().findBestPackage(packageFoundCallback, this);
     }
 
     private final PackageFoundCallback packageFoundCallback = new PackageFoundCallback() {

--- a/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoApplication.java
+++ b/demo-extended/src/main/java/com/novoda/simplechromecustomtabs/demo/ExtendedDemoApplication.java
@@ -2,12 +2,9 @@ package com.novoda.simplechromecustomtabs.demo;
 
 import android.app.Application;
 
-import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
-
 public class ExtendedDemoApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        SimpleChromeCustomTabs.initialize(this);
     }
 }

--- a/demo-simple/src/main/java/com/novoda/simplechromecustomtabs/demo/SimpleDemoActivity.java
+++ b/demo-simple/src/main/java/com/novoda/simplechromecustomtabs/demo/SimpleDemoActivity.java
@@ -54,7 +54,7 @@ public class SimpleDemoActivity extends AppCompatActivity {
     }
 
     private void checkForPackageAvailable() {
-        SimpleChromeCustomTabs.getInstance().findBestPackage(packageFoundCallback);
+        SimpleChromeCustomTabs.getInstance().findBestPackage(packageFoundCallback, this);
     }
 
     private final PackageFoundCallback packageFoundCallback = new PackageFoundCallback() {

--- a/demo-simple/src/main/java/com/novoda/simplechromecustomtabs/demo/SimpleDemoApplication.java
+++ b/demo-simple/src/main/java/com/novoda/simplechromecustomtabs/demo/SimpleDemoApplication.java
@@ -2,12 +2,9 @@ package com.novoda.simplechromecustomtabs.demo;
 
 import android.app.Application;
 
-import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
-
 public class SimpleDemoApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        SimpleChromeCustomTabs.initialize(this);
     }
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -24,10 +24,10 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
     private AvailableAppProvider availableAppProvider;
 
     /**
-     * @deprecated There is no need to call it anymore in order to use this library,
+     * This is not needed for library use but it may become needed in the future,
      * use {@link #getInstance()} instead
      */
-    @Deprecated public static void initialize(Context context) {
+    public static void initialize(Context context) {
         // do nothing
     }
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -23,6 +23,14 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
     private WebNavigator webNavigator;
     private AvailableAppProvider availableAppProvider;
 
+    /**
+     * @deprecated There is no need to call it anymore in order to use this library,
+     * use {@link #getInstance()} instead
+     */
+    @Deprecated public static void initialize(Context context) {
+        // do nothing
+    }
+
     public static SimpleChromeCustomTabs getInstance() {
         return LazyHolder.INSTANCE.getSimpleChromeCustomTabs();
     }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -52,7 +52,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
     /**
      * Provides a {@link NavigationFallback} to specify navigation mechanism in case of no Chrome Custom Tabs support found.
      *
-     * @return WebNavigator with navigation fallback.
+     * @param navigationFallback a {@link NavigationFallback} with the routine to be invoked if the navigation fails
+     *
+     * @return {@link WebNavigator} with {@link NavigationFallback}.
      */
     @Override
     public WebNavigator withFallback(NavigationFallback navigationFallback) {
@@ -63,7 +65,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
      * Provides a {@link IntentCustomizer} to be used to customize the Chrome Custom Tabs by attacking directly to
      * {@link SimpleChromeCustomTabsIntentBuilder}
      *
-     * @return WebNavigator with customized Chrome Custom Tabs.
+     * @param intentCustomizer an {@link IntentCustomizer} used to style the chrome custom tab
+     *
+     * @return {@link WebNavigator} with customized Chrome Custom Tabs.
      */
     @Override
     public WebNavigator withIntentCustomizer(IntentCustomizer intentCustomizer) {
@@ -74,6 +78,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
      * Navigates to the given url using Chrome Custom Tabs if available.
      * If there is no application supporting Chrome Custom Tabs and {@link NavigationFallback}
      * is provided it will be used to redirect navigation.
+     *
+     * @param url the {@link Uri} to be used for navigation. Must be a well formed http / https address.
+     *
      */
     @Override
     public void navigateTo(Uri url, Activity activityContext) {
@@ -90,6 +97,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
 
     /**
      * Connects given activity to {@link android.support.customtabs.CustomTabsService}
+     *
+     * @param activity the {@link Activity} to which the custom tabs service will be bound
+     *
      */
     @Override
     public void connectTo(@NonNull Activity activity) {
@@ -106,6 +116,8 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
     /**
      * Tells SimpleChromeCustomTabs that a potential Url might be launched. This will do pre DNS resolution that will speed things up
      * but it will as well require network usage which can affect batter performance.
+     *
+     * @param uri the {@link Uri} to be used for navigation. Must be a well formed http / https address.
      */
     @Override
     public void mayLaunch(Uri uri) {
@@ -138,6 +150,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
 
     /**
      * Asynchronous search for the best package with support for Chrome Custom Tabs.
+     *
+     * @param packageFoundCallback a {@link com.novoda.simplechromecustomtabs.provider.AvailableAppProvider.PackageFoundCallback} with the routine
+     *                             to be invoked whenever a search for packages giving support for chrome custom tabs is completed.
      */
     @Override
     public void findBestPackage(@NonNull AvailableAppProvider.PackageFoundCallback packageFoundCallback, Context context) {

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -19,23 +19,19 @@ import java.util.List;
 
 public final class SimpleChromeCustomTabs implements WebNavigator, Connection, AvailableAppProvider {
 
-    private final Connection connection;
-    private final WebNavigator webNavigator;
-    private final AvailableAppProvider availableAppProvider;
+    private Connection connection;
+    private WebNavigator webNavigator;
+    private AvailableAppProvider availableAppProvider;
 
     public static SimpleChromeCustomTabs getInstance() {
-        return LazyHolder.INSTANCE;
+        return LazyHolder.INSTANCE.getSimpleChromeCustomTabs();
     }
 
     private static class LazyHolder {
-        private static final SimpleChromeCustomTabs INSTANCE = new SimpleChromeCustomTabs(
-                Connection.Creator.create(),
-                WebNavigator.Creator.create(),
-                AvailableAppProvider.Creator.create()
-        );
+        private static final SimpleChromeCustomTabsProvider INSTANCE = new SimpleChromeCustomTabsProvider();
     }
 
-    private SimpleChromeCustomTabs(Connection connection, WebNavigator webNavigator, AvailableAppProvider availableAppProvider) {
+    void injectModules(Connection connection, WebNavigator webNavigator, AvailableAppProvider availableAppProvider) {
         this.connection = connection;
         this.webNavigator = webNavigator;
         this.availableAppProvider = availableAppProvider;

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -143,12 +143,4 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
     public void findBestPackage(@NonNull AvailableAppProvider.PackageFoundCallback packageFoundCallback, Context context) {
         availableAppProvider.findBestPackage(packageFoundCallback, context);
     }
-
-    /**
-     * @deprecated use {@link #findBestPackage(PackageFoundCallback, Context)} instead
-     */
-    @Override
-    @Deprecated public void findBestPackage(@NonNull PackageFoundCallback packageFoundCallback) {
-        // do nothing
-    }
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsSession;
 
-import com.novoda.notils.exception.DeveloperError;
 import com.novoda.simplechromecustomtabs.connection.Connection;
 import com.novoda.simplechromecustomtabs.connection.Session;
 import com.novoda.simplechromecustomtabs.navigation.IntentCustomizer;
@@ -20,42 +19,31 @@ import java.util.List;
 
 public final class SimpleChromeCustomTabs implements WebNavigator, Connection, AvailableAppProvider {
 
-    private static Context applicationContext;
-    private Connection connection;
-    private WebNavigator webNavigator;
-    private AvailableAppProvider availableAppProvider;
-
-    private SimpleChromeCustomTabs() {
-        //no-op
-    }
-
-    private static class LazyHolder {
-        private static final SimpleChromeCustomTabs INSTANCE = new SimpleChromeCustomTabs();
-    }
+    private final Connection connection;
+    private final WebNavigator webNavigator;
+    private final AvailableAppProvider availableAppProvider;
 
     public static SimpleChromeCustomTabs getInstance() {
-        if (applicationContext == null) {
-            throw new DeveloperError("SimpleChromeCustomTabs must be initialized. Use SimpleChromeCustomTabs.initialize(context)");
-        }
-
         return LazyHolder.INSTANCE;
     }
 
-    public static void initialize(Context context) {
-        applicationContext = context.getApplicationContext();
-        LazyHolder.INSTANCE.connection = Connection.Creator.create();
-        LazyHolder.INSTANCE.webNavigator = WebNavigator.Creator.create();
-        LazyHolder.INSTANCE.availableAppProvider = AvailableAppProvider.Creator.create();
+    private static class LazyHolder {
+        private static final SimpleChromeCustomTabs INSTANCE = new SimpleChromeCustomTabs(
+                Connection.Creator.create(),
+                WebNavigator.Creator.create(),
+                AvailableAppProvider.Creator.create()
+        );
     }
 
-    public Context getContext() {
-        return applicationContext;
+    private SimpleChromeCustomTabs(Connection connection, WebNavigator webNavigator, AvailableAppProvider availableAppProvider) {
+        this.connection = connection;
+        this.webNavigator = webNavigator;
+        this.availableAppProvider = availableAppProvider;
     }
 
     /**
      * Provides a {@link NavigationFallback} to specify navigation mechanism in case of no Chrome Custom Tabs support found.
      *
-     * @param navigationFallback
      * @return WebNavigator with navigation fallback.
      */
     @Override
@@ -67,7 +55,6 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
      * Provides a {@link IntentCustomizer} to be used to customize the Chrome Custom Tabs by attacking directly to
      * {@link SimpleChromeCustomTabsIntentBuilder}
      *
-     * @param intentCustomizer
      * @return WebNavigator with customized Chrome Custom Tabs.
      */
     @Override
@@ -79,9 +66,6 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
      * Navigates to the given url using Chrome Custom Tabs if available.
      * If there is no application supporting Chrome Custom Tabs and {@link NavigationFallback}
      * is provided it will be used to redirect navigation.
-     *
-     * @param url
-     * @param activityContext
      */
     @Override
     public void navigateTo(Uri url, Activity activityContext) {
@@ -98,8 +82,6 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
 
     /**
      * Connects given activity to {@link android.support.customtabs.CustomTabsService}
-     *
-     * @param activity
      */
     @Override
     public void connectTo(@NonNull Activity activity) {
@@ -116,8 +98,6 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
     /**
      * Tells SimpleChromeCustomTabs that a potential Url might be launched. This will do pre DNS resolution that will speed things up
      * but it will as well require network usage which can affect batter performance.
-     *
-     * @param uri
      */
     @Override
     public void mayLaunch(Uri uri) {
@@ -150,11 +130,9 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
 
     /**
      * Asynchronous search for the best package with support for Chrome Custom Tabs.
-     *
-     * @param packageFoundCallback
      */
     @Override
-    public void findBestPackage(@NonNull AvailableAppProvider.PackageFoundCallback packageFoundCallback) {
-        availableAppProvider.findBestPackage(packageFoundCallback);
+    public void findBestPackage(@NonNull AvailableAppProvider.PackageFoundCallback packageFoundCallback, Context context) {
+        availableAppProvider.findBestPackage(packageFoundCallback, context);
     }
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabs.java
@@ -39,6 +39,10 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
         private static final SimpleChromeCustomTabsProvider INSTANCE = new SimpleChromeCustomTabsProvider();
     }
 
+    SimpleChromeCustomTabs() {
+        // no-op
+    }
+
     void injectModules(Connection connection, WebNavigator webNavigator, AvailableAppProvider availableAppProvider) {
         this.connection = connection;
         this.webNavigator = webNavigator;
@@ -138,5 +142,13 @@ public final class SimpleChromeCustomTabs implements WebNavigator, Connection, A
     @Override
     public void findBestPackage(@NonNull AvailableAppProvider.PackageFoundCallback packageFoundCallback, Context context) {
         availableAppProvider.findBestPackage(packageFoundCallback, context);
+    }
+
+    /**
+     * @deprecated use {@link #findBestPackage(PackageFoundCallback, Context)} instead
+     */
+    @Override
+    @Deprecated public void findBestPackage(@NonNull PackageFoundCallback packageFoundCallback) {
+        // do nothing
     }
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsProvider.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsProvider.java
@@ -1,0 +1,24 @@
+package com.novoda.simplechromecustomtabs;
+
+import com.novoda.simplechromecustomtabs.connection.Connection;
+import com.novoda.simplechromecustomtabs.navigation.WebNavigator;
+import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
+
+class SimpleChromeCustomTabsProvider {
+
+    private final SimpleChromeCustomTabs simpleChromeCustomTabs;
+
+    public SimpleChromeCustomTabsProvider() {
+        simpleChromeCustomTabs = new SimpleChromeCustomTabs();
+
+        Connection connection = Connection.Creator.create(simpleChromeCustomTabs);
+        WebNavigator webNavigator = WebNavigator.Creator.create(simpleChromeCustomTabs);
+        AvailableAppProvider availableAppProvider = AvailableAppProvider.Creator.create();
+
+        simpleChromeCustomTabs.injectModules(connection, webNavigator, availableAppProvider);
+    }
+
+    public SimpleChromeCustomTabs getSimpleChromeCustomTabs() {
+        return simpleChromeCustomTabs;
+    }
+}

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsProvider.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsProvider.java
@@ -8,7 +8,7 @@ class SimpleChromeCustomTabsProvider {
 
     private final SimpleChromeCustomTabs simpleChromeCustomTabs;
 
-    public SimpleChromeCustomTabsProvider() {
+    SimpleChromeCustomTabsProvider() {
         simpleChromeCustomTabs = new SimpleChromeCustomTabs();
 
         Connection connection = Connection.Creator.create(simpleChromeCustomTabs);
@@ -18,7 +18,7 @@ class SimpleChromeCustomTabsProvider {
         simpleChromeCustomTabs.injectModules(connection, webNavigator, availableAppProvider);
     }
 
-    public SimpleChromeCustomTabs getSimpleChromeCustomTabs() {
+    SimpleChromeCustomTabs getSimpleChromeCustomTabs() {
         return simpleChromeCustomTabs;
     }
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
@@ -41,7 +41,7 @@ class Binder {
                     public void onPackageNotFound() {
                         serviceConnection = null;
                     }
-                }
+                }, context
         );
     }
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Binder.java
@@ -7,7 +7,6 @@ import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsServiceConnection;
 import android.util.Log;
 
-import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
 import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
 
 class Binder {
@@ -17,11 +16,6 @@ class Binder {
 
     Binder(@NonNull AvailableAppProvider availableAppProvider) {
         this.availableAppProvider = availableAppProvider;
-    }
-
-    public static Binder newInstance() {
-        AvailableAppProvider availableAppProvider = SimpleChromeCustomTabs.getInstance();
-        return new Binder(availableAppProvider);
     }
 
     public void bindCustomTabsServiceTo(@NonNull final Context context, ServiceConnectionCallback callback) {

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Connection.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/Connection.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 
 import com.novoda.notils.exception.DeveloperError;
+import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
 
 public interface Connection {
 
@@ -26,8 +27,8 @@ public interface Connection {
             throw new DeveloperError("Shouldn't be instantiated");
         }
 
-        public static Connection create() {
-            Binder binder = Binder.newInstance();
+        public static Connection create(AvailableAppProvider availableAppProvider) {
+            Binder binder = new Binder(availableAppProvider);
             return new SimpleChromeCustomTabsConnection(binder);
         }
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
-public class SimpleChromeCustomTabsConnection implements Connection, ServiceConnectionCallback {
+class SimpleChromeCustomTabsConnection implements Connection, ServiceConnectionCallback {
 
     private final Binder binder;
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/connection/SimpleChromeCustomTabsConnection.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
-class SimpleChromeCustomTabsConnection implements Connection, ServiceConnectionCallback {
+public class SimpleChromeCustomTabsConnection implements Connection, ServiceConnectionCallback {
 
     private final Binder binder;
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/WebNavigator.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/navigation/WebNavigator.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.net.Uri;
 
 import com.novoda.notils.exception.DeveloperError;
-import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
 import com.novoda.simplechromecustomtabs.connection.Connection;
 
 public interface WebNavigator {
@@ -23,11 +22,8 @@ public interface WebNavigator {
             throw new DeveloperError("Shouldn't be instantiated");
         }
 
-        public static WebNavigator create() {
-            Connection connection = SimpleChromeCustomTabs.getInstance();
+        public static WebNavigator create(Connection connection) {
             return new SimpleChromeCustomTabsWebNavigator(connection);
         }
-
     }
-
 }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/provider/AvailableAppProvider.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/provider/AvailableAppProvider.java
@@ -1,5 +1,6 @@
 package com.novoda.simplechromecustomtabs.provider;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 
 import com.novoda.notils.exception.DeveloperError;
@@ -9,7 +10,7 @@ import java.util.concurrent.Executors;
 
 public interface AvailableAppProvider {
 
-    void findBestPackage(@NonNull SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback packageFoundCallback);
+    void findBestPackage(@NonNull SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback packageFoundCallback, Context context);
 
     interface PackageFoundCallback {
         void onPackageFound(String packageName);
@@ -24,7 +25,7 @@ public interface AvailableAppProvider {
         }
 
         public static AvailableAppProvider create() {
-            BestPackageFinder bestPackageFinder = BestPackageFinder.newInstance();
+            BestPackageFinder bestPackageFinder = new BestPackageFinder();
             Executor executor = Executors.newSingleThreadExecutor();
             return new SimpleChromeCustomTabsAvailableAppProvider(bestPackageFinder, executor);
         }

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/provider/AvailableAppProvider.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/provider/AvailableAppProvider.java
@@ -12,9 +12,6 @@ public interface AvailableAppProvider {
 
     void findBestPackage(@NonNull SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback packageFoundCallback, Context context);
 
-    @Deprecated
-    void findBestPackage(@NonNull SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback packageFoundCallback);
-
     interface PackageFoundCallback {
         void onPackageFound(String packageName);
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/provider/AvailableAppProvider.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/provider/AvailableAppProvider.java
@@ -12,6 +12,9 @@ public interface AvailableAppProvider {
 
     void findBestPackage(@NonNull SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback packageFoundCallback, Context context);
 
+    @Deprecated
+    void findBestPackage(@NonNull SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback packageFoundCallback);
+
     interface PackageFoundCallback {
         void onPackageFound(String packageName);
 

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/provider/BestPackageFinder.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/provider/BestPackageFinder.java
@@ -9,8 +9,6 @@ import android.support.annotation.WorkerThread;
 import android.support.customtabs.CustomTabsService;
 import android.text.TextUtils;
 
-import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,26 +18,15 @@ class BestPackageFinder {
     private static final String ANY_URL = "http://www.example.com";
     private static final Intent INTENT_TO_EXTERNAL_LINK = new Intent(Intent.ACTION_VIEW, Uri.parse(ANY_URL));
 
-    private final PackageManager packageManager;
-
-    BestPackageFinder(PackageManager packageManager) {
-        this.packageManager = packageManager;
-    }
-
-    public static BestPackageFinder newInstance() {
-        Context context = SimpleChromeCustomTabs.getInstance().getContext();
-        PackageManager packageManager = context.getPackageManager();
-        return new BestPackageFinder(packageManager);
-    }
-
     @WorkerThread
-    public String findBestPackage() {
-        List<String> packagesSupportingCustomTabs = getPackagesSupportingCustomTabs();
+    public String findBestPackage(Context context) {
+        PackageManager packageManager = context.getPackageManager();
+        List<String> packagesSupportingCustomTabs = getPackagesSupportingCustomTabs(packageManager);
         if (packagesSupportingCustomTabs.isEmpty()) {
             return NO_PACKAGE_FOUND;
         }
 
-        String defaultPackage = getDefaultPackage();
+        String defaultPackage = getDefaultPackage(packageManager);
         if (packagesSupportingCustomTabs.contains(defaultPackage)) {
             return defaultPackage;
         }
@@ -47,7 +34,7 @@ class BestPackageFinder {
         return packagesSupportingCustomTabs.get(0);
     }
 
-    private String getDefaultPackage() {
+    private String getDefaultPackage(PackageManager packageManager) {
         ResolveInfo defaultActivityInfo = packageManager.resolveActivity(INTENT_TO_EXTERNAL_LINK, 0);
 
         if (defaultActivityInfo == null) {
@@ -59,7 +46,7 @@ class BestPackageFinder {
         return TextUtils.isEmpty(packageName) ? NO_PACKAGE_FOUND : packageName;
     }
 
-    private List<String> getPackagesSupportingCustomTabs() {
+    private List<String> getPackagesSupportingCustomTabs(PackageManager packageManager) {
         List<ResolveInfo> resolvedInfoList = packageManager.queryIntentActivities(INTENT_TO_EXTERNAL_LINK, 0);
         List<String> packagesSupportingCustomTabs = new ArrayList<>();
         for (ResolveInfo info : resolvedInfoList) {

--- a/library/src/main/java/com/novoda/simplechromecustomtabs/provider/SimpleChromeCustomTabsAvailableAppProvider.java
+++ b/library/src/main/java/com/novoda/simplechromecustomtabs/provider/SimpleChromeCustomTabsAvailableAppProvider.java
@@ -1,5 +1,6 @@
 package com.novoda.simplechromecustomtabs.provider;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 import android.text.TextUtils;
@@ -18,16 +19,16 @@ class SimpleChromeCustomTabsAvailableAppProvider implements AvailableAppProvider
 
     @Override
     @WorkerThread
-    public void findBestPackage(@NonNull final PackageFoundCallback packageFoundCallback) {
-        Runnable findBestPackageTask = findBestPackageTask(packageFoundCallback);
+    public void findBestPackage(@NonNull PackageFoundCallback packageFoundCallback, Context context) {
+        Runnable findBestPackageTask = findBestPackageTask(packageFoundCallback, context);
         executor.execute(findBestPackageTask);
     }
 
-    private Runnable findBestPackageTask(final PackageFoundCallback packageFoundCallback) {
+    private Runnable findBestPackageTask(final PackageFoundCallback packageFoundCallback, final Context context) {
         return new Runnable() {
             @Override
             public void run() {
-                String packageName = bestPackageFinder.findBestPackage();
+                String packageName = bestPackageFinder.findBestPackage(context);
                 if (TextUtils.isEmpty(packageName)) {
                     packageFoundCallback.onPackageNotFound();
                 } else {

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
@@ -10,7 +10,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class SimpleChromeCustomTabsTest {
 
     @Test
-    public void givenSimpleChromeCustomTabsIsInitialised_whenGettingInstance_thenInstanceIsReturned() {
+    public void whenGettingInstance_thenInstanceIsReturned() {
         assertThat(SimpleChromeCustomTabs.getInstance()).isInstanceOf(SimpleChromeCustomTabs.class);
     }
 }

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/SimpleChromeCustomTabsTest.java
@@ -1,37 +1,16 @@
 package com.novoda.simplechromecustomtabs;
 
-import com.novoda.notils.exception.DeveloperError;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
 
 @RunWith(RobolectricTestRunner.class)
 public class SimpleChromeCustomTabsTest {
 
     @Test
-    public void givenSimpleChromeCustomTabsIsNotInitialised_whenGettingInstance_thenDeveloperErrorIsThrown() {
-        /** Please forgive me for what you are seeing. Given some incompatibility issues between Robolectric 3.1.4 and some versions of
-         *  Java 8, the @Test(expected = DeveloperError.class) wasn't working.
-         *  Will fix when we figure out how.
-         **/
-        try {
-            SimpleChromeCustomTabs.getInstance();
-            fail("A Developer error exception was expected, but there was nothing");
-        } catch (DeveloperError e) {
-            // passes
-        }
-    }
-
-    @Test
     public void givenSimpleChromeCustomTabsIsInitialised_whenGettingInstance_thenInstanceIsReturned() {
-        SimpleChromeCustomTabs.initialize(RuntimeEnvironment.application);
-
         assertThat(SimpleChromeCustomTabs.getInstance()).isInstanceOf(SimpleChromeCustomTabs.class);
     }
-
 }

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/connection/BinderTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/connection/BinderTest.java
@@ -1,25 +1,31 @@
 package com.novoda.simplechromecustomtabs.connection;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 
 import com.novoda.simplechromecustomtabs.provider.AvailableAppProvider;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 
 import static com.novoda.simplechromecustomtabs.provider.AvailableAppProvider.PackageFoundCallback;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(RobolectricTestRunner.class)
 public class BinderTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private Activity mockActivity;
@@ -34,8 +40,6 @@ public class BinderTest {
 
     @Before
     public void setUp() {
-        initMocks(this);
-
         packageFoundCallbackCaptor = ArgumentCaptor.forClass(PackageFoundCallback.class);
         binder = new Binder(mockAvailableAppProvider);
     }
@@ -98,12 +102,12 @@ public class BinderTest {
     }
 
     private void whenPackageIsFound() {
-        verify(mockAvailableAppProvider).findBestPackage(packageFoundCallbackCaptor.capture());
+        verify(mockAvailableAppProvider).findBestPackage(packageFoundCallbackCaptor.capture(), any(Context.class));
         packageFoundCallbackCaptor.getValue().onPackageFound("anyPackage");
     }
 
     private void whenPackageIsNotFound() {
-        verify(mockAvailableAppProvider).findBestPackage(packageFoundCallbackCaptor.capture());
+        verify(mockAvailableAppProvider).findBestPackage(packageFoundCallbackCaptor.capture(), any(Context.class));
         packageFoundCallbackCaptor.getValue().onPackageNotFound();
     }
 

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigatorTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/navigation/SimpleChromeCustomTabsWebNavigatorTest.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.net.Uri;
 import android.support.customtabs.CustomTabsIntent;
 
-import com.novoda.simplechromecustomtabs.SimpleChromeCustomTabs;
 import com.novoda.simplechromecustomtabs.connection.Connection;
 import com.novoda.simplechromecustomtabs.connection.Session;
 
@@ -12,9 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -43,7 +40,6 @@ public class SimpleChromeCustomTabsWebNavigatorTest {
     public void setUp() {
         initMocks(this);
 
-        SimpleChromeCustomTabs.initialize(RuntimeEnvironment.application);
         when(mockIntentCustomizer.onCustomiseIntent(any(SimpleChromeCustomTabsIntentBuilder.class))).thenReturn(mockSimpleChromeCustomTabsIntentBuilder);
         when(mockSimpleChromeCustomTabsIntentBuilder.createIntent()).thenReturn(ANY_INTENT);
         when(mockConnection.getSession()).thenReturn(Session.NULL_SESSION);

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/provider/BestPackageFinderTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/provider/BestPackageFinderTest.java
@@ -1,5 +1,6 @@
 package com.novoda.simplechromecustomtabs.provider;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
@@ -10,37 +11,44 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(RobolectricTestRunner.class)
 public class BestPackageFinderTest {
 
     private static final String DEFAULT_PACKAGE = "default.package";
     private static final String OTHER_PACKAGE = "other.package";
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
     @Mock
     private PackageManager mockPackageManager;
+    @Mock
+    private Activity mockActivity;
 
     private BestPackageFinder bestPackageFinder;
 
     @Before
     public void setUp() {
-        initMocks(this);
-
-        bestPackageFinder = new BestPackageFinder(mockPackageManager);
+        bestPackageFinder = new BestPackageFinder();
+        when(mockActivity.getPackageManager()).thenReturn(mockPackageManager);
     }
 
     @Test
     public void returnsEmptyPackageIfNoPackageSupportingCustomTabsIsFound() {
         givenThatThereIsNoPackagesSupportingCustomTabs();
 
-        assertThat(bestPackageFinder.findBestPackage()).isEmpty();
+        assertThat(bestPackageFinder.findBestPackage(mockActivity)).isEmpty();
     }
 
     @Test
@@ -48,7 +56,7 @@ public class BestPackageFinderTest {
         givenThatDefaultPackageIs(DEFAULT_PACKAGE);
         givenThatPackagesSupportingCustomTabsIs(DEFAULT_PACKAGE);
 
-        assertThat(bestPackageFinder.findBestPackage()).isEqualTo(DEFAULT_PACKAGE);
+        assertThat(bestPackageFinder.findBestPackage(mockActivity)).isEqualTo(DEFAULT_PACKAGE);
     }
 
     @Test
@@ -56,7 +64,7 @@ public class BestPackageFinderTest {
         givenThatDefaultPackageIs(DEFAULT_PACKAGE);
         givenThatPackagesSupportingCustomTabsIs(OTHER_PACKAGE);
 
-        assertThat(bestPackageFinder.findBestPackage()).isEqualTo(OTHER_PACKAGE);
+        assertThat(bestPackageFinder.findBestPackage(mockActivity)).isEqualTo(OTHER_PACKAGE);
     }
 
     private void givenThatThereIsNoPackagesSupportingCustomTabs() {

--- a/library/src/test/java/com/novoda/simplechromecustomtabs/provider/SimpleChromeCustomTabsAvailableAppProviderTest.java
+++ b/library/src/test/java/com/novoda/simplechromecustomtabs/provider/SimpleChromeCustomTabsAvailableAppProviderTest.java
@@ -1,5 +1,7 @@
 package com.novoda.simplechromecustomtabs.provider;
 
+import android.app.Activity;
+
 import java.util.concurrent.Executor;
 
 import org.junit.Before;
@@ -21,6 +23,8 @@ public class SimpleChromeCustomTabsAvailableAppProviderTest {
     private BestPackageFinder mockBestPackageFinder;
     @Mock
     private SimpleChromeCustomTabsAvailableAppProvider.PackageFoundCallback mockPackageFoundCallback;
+    @Mock
+    private Activity mockActivity;
 
     private SimpleChromeCustomTabsAvailableAppProvider simpleChromeCustomTabsAvailableAppProvider;
 
@@ -33,16 +37,16 @@ public class SimpleChromeCustomTabsAvailableAppProviderTest {
 
     @Test
     public void findBestPackageDelegatesToPackageFinder() {
-        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback);
+        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback, mockActivity);
 
-        verify(mockBestPackageFinder).findBestPackage();
+        verify(mockBestPackageFinder).findBestPackage(mockActivity);
     }
 
     @Test
     public void packageIsFoundIfNotNullOrEmpty() {
         givenThatPackageNameIsNotNullOrEmpty();
 
-        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback);
+        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback, mockActivity);
 
         verify(mockPackageFoundCallback).onPackageFound(NON_EMPTY_PACKAGE);
     }
@@ -51,7 +55,7 @@ public class SimpleChromeCustomTabsAvailableAppProviderTest {
     public void packageIsNotFoundIfNull() {
         givenThatPackageIsNull();
 
-        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback);
+        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback, mockActivity);
 
         verify(mockPackageFoundCallback).onPackageNotFound();
     }
@@ -60,7 +64,7 @@ public class SimpleChromeCustomTabsAvailableAppProviderTest {
     public void packageNotFoundIfEmpty() {
         givenThatPackageIsEmpty();
 
-        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback);
+        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback, mockActivity);
 
         verify(mockPackageFoundCallback).onPackageNotFound();
     }
@@ -69,7 +73,7 @@ public class SimpleChromeCustomTabsAvailableAppProviderTest {
     public void ifPackageIsFoundThenPackageNotFoundWillNotBeCalled() {
         givenThatPackageIsFound();
 
-        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback);
+        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback, mockActivity);
 
         verify(mockPackageFoundCallback, never()).onPackageNotFound();
     }
@@ -78,21 +82,21 @@ public class SimpleChromeCustomTabsAvailableAppProviderTest {
     public void ifPackageIsNotFoundThenPackageFoundWillNotBeCalled() {
         givenThatPackageIsNotFound();
 
-        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback);
+        simpleChromeCustomTabsAvailableAppProvider.findBestPackage(mockPackageFoundCallback, mockActivity);
 
         verify(mockPackageFoundCallback, never()).onPackageFound(anyString());
     }
 
     private void givenThatPackageNameIsNotNullOrEmpty() {
-        when(mockBestPackageFinder.findBestPackage()).thenReturn(NON_EMPTY_PACKAGE);
+        when(mockBestPackageFinder.findBestPackage(mockActivity)).thenReturn(NON_EMPTY_PACKAGE);
     }
 
     private void givenThatPackageIsNull() {
-        when(mockBestPackageFinder.findBestPackage()).thenReturn(null);
+        when(mockBestPackageFinder.findBestPackage(mockActivity)).thenReturn(null);
     }
 
     private void givenThatPackageIsEmpty() {
-        when(mockBestPackageFinder.findBestPackage()).thenReturn("");
+        when(mockBestPackageFinder.findBestPackage(mockActivity)).thenReturn("");
     }
 
     private void givenThatPackageIsFound() {


### PR DESCRIPTION
### Task Requested ###

The library requires the invocation of an initialisation method before actually using the library and the library statically holds the application context.

### Solution implemented ###

We have dropped the need of the initialisation invocation and also the static reference to the application context.

The `SimpleChromeCustomTabs` had a circular dependency on the `binder` and its solved by delegating the instantiation of all the dependencies to a `SimpleChromeCustomTabsProvider` that ensures that there is no circular dependencies at instantiation time.

As a downside we have had to provide a package protected method that injects the dependencies in the `SimpleChromeCustomTabs`. This can probably be avoided but a big chunk of the library would have to be rewritten. This PR provides minimum impact and solves the two mentioned issues.

Clients are not forced anymore to call `SimpleChromeCustomTabs.initialize(this);` at their application level.

**Test added**

All tests have been upgraded

Screenshots

No UI changes