### PR TITLE
Upgrade library version to 0.1.5

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -41,7 +41,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'simple-chrome-custom-tabs'
-    publishVersion = '0.1.4'
+    publishVersion = '0.1.5'
     description = 'Provides easy integration of Chrome Custom Tabs into your project.'
     website = 'https://github.com/novoda/simplechromecustomtabs'
 }


### PR DESCRIPTION
### Task Requested ###

Upgrade library version to 0.1.5

This release includes:
- There is no need to call SimpleChromeCustomTabs.initialize(context);
- The library doesn't hold a static reference to the context anymore

PRs included:
- Remove static initialiser #37

### Screenshots ###

No UI changes