### PR TITLE
Increase version to 0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.novoda:simple-chrome-custom-tabs:0.1.5'
+    compile 'com.novoda:simple-chrome-custom-tabs:0.1.6'
 }
 ```    
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,7 +40,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'simple-chrome-custom-tabs'
-    publishVersion = '0.1.5'
+    publishVersion = '0.1.6'
     description = 'Provides easy integration of Chrome Custom Tabs into your project.'
     website = 'https://github.com/novoda/simplechromecustomtabs'
 }


### PR DESCRIPTION
Intended release:

```
0.1.6

- replaces DeveloperError from Notils with IllegalStateException from std lib; removes notils dependency #40
```

I don't understand why the diff for the readme is so big - I only changed one digit :thinking: (line 34)